### PR TITLE
fix: use olympe.Drone instead of olympe.SkyController for Olympe >=7.x

### DIFF
--- a/anafi_ros_nodes/anafi_ros_nodes/anafi.py
+++ b/anafi_ros_nodes/anafi_ros_nodes/anafi.py
@@ -185,7 +185,7 @@ class Anafi(Node):
 
 		if self.skycontroller_enabled:  # connect to SkyController
 			self.node.get_logger().info("Connecting through SkyController")
-			self.drone = olympe.SkyController(self.ip) # self.drone = olympe.Drone(self.ip)
+			self.drone = olympe.Drone(self.ip)
 			#self.skyctrl = self.drone  # TODO: remove
 		else:  # connect to Anafi
 			self.node.get_logger().info("Connecting directly to Anafi")


### PR DESCRIPTION
## Problem

`olympe.SkyController()` fails to connect when using Olympe 7.x (tested on 7.7.5), 
returning `False` on `connect()` with a connection timeout error:
olympe.drone - connect - '192.168.53.1' connection timed out
olympe.drone - _do_connect - '192.168.53.1 connection retries failed

This makes it impossible to use `anafi_ros` via SkyController with recent 
versions of the Olympe SDK.

## Root Cause

The `olympe.SkyController()` constructor appears to be broken in Olympe 7.x. 
`olympe.Drone()` already handles both connection types automatically based on 
the IP address prefix, which is already used in the `else` branch of the same 
condition.

## Fix

Replace `olympe.SkyController(self.ip)` with `olympe.Drone(self.ip)`.  
`olympe.Drone()` correctly identifies the connection type by IP:
- `192.168.42.1` → direct WiFi connection to the drone
- `192.168.53.1` → connection through SkyController

## Tested on

- Ubuntu 22.04
- ROS2 Humble
- Olympe 7.7.5
- Parrot ANAFI 4K + SkyController 3