### PR TITLE
Document requests as a dependency of anafi_ros_nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ This package has been tested with **python3** in **ROS2 Humble**/**Ubuntu 22.04*
 
       pip install scipy
 
+- [Requests](https://pypi.org/project/requests/) - library for making HTTP requests:
+
+      pip install requests
+
 > [!NOTE]  
 > To install Python packages using `pip` in Ubuntu 24.04, you can add `--break-system-packages` flag:
 > 


### PR DESCRIPTION
anafi_ros_nodes/anafi.py imports requests directly, but it is not listed in the Dependencies section, so a clean install fails with ModuleNotFoundError: No module named 'requests'.